### PR TITLE
[FEAT]/#15-Share객체 저장 Redis로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     implementation 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/chimaera/wagubook/config/RedisConfig.java
+++ b/src/main/java/com/chimaera/wagubook/config/RedisConfig.java
@@ -1,11 +1,14 @@
 package com.chimaera.wagubook.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -32,14 +35,14 @@ public class RedisConfig {
 
         // Key-Value 형태로 직렬화 수행
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         // Hash Key-Value 형태로 직렬화 수행
-        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+//        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
 
         // 기본적으로 직렬화 수행
-        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+//        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
 
         return redisTemplate;
     }

--- a/src/main/java/com/chimaera/wagubook/controller/ShareController.java
+++ b/src/main/java/com/chimaera/wagubook/controller/ShareController.java
@@ -87,10 +87,10 @@ public class ShareController {
      * 투표에 추가 기능
      * url : /share/{share_id}?store_id={store_id}
      * */
-    @PostMapping("/share/{share_id}")
+    @PostMapping("/share/{url}")
     @Operation(summary = "투표에 추가 기능")
     public ResponseEntity<String> addVoteStore(
-            @PathVariable String share_id,
+            @PathVariable String url,
             @RequestParam String store_id,
             HttpSession session){
 
@@ -99,17 +99,17 @@ public class ShareController {
             throw new CustomException(ErrorCode.REQUEST_LOGIN);
         }
 
-        return new ResponseEntity<>(shareService.addVoteStore(share_id,store_id), HttpStatus.OK);
+        return new ResponseEntity<>(shareService.addVoteStore(url,store_id), HttpStatus.OK);
     }
 
     /**
      * 투표에서 삭제 기능
-     * url : /share/{share_id}?store={store_id}
+     * url : /share/{url}?store={store_id}
      * */
-    @DeleteMapping("/share/{share_id}")
+    @DeleteMapping("/share/{url}")
     @Operation(summary = "투표에서 삭제 기능")
     public ResponseEntity<String> deleteVoteStore(
-            @PathVariable String share_id,
+            @PathVariable String url,
             @RequestParam String store_id,
             HttpSession session){
 
@@ -118,56 +118,56 @@ public class ShareController {
             throw new CustomException(ErrorCode.REQUEST_LOGIN);
         }
 
-        return new ResponseEntity<>(shareService.deleteVoteStore(share_id,store_id), HttpStatus.OK);
+        return new ResponseEntity<>(shareService.deleteVoteStore(url,store_id), HttpStatus.OK);
     }
 
     /**
      * 투표 좋아요
-     * url : /share/{share_id}/vote?store={store_id}
+     * url : /share/{url}/vote?store={store_id}
      * */
-    @PostMapping("/share/{share_id}/vote")
+    @PostMapping("/share/{url}/vote")
     @Operation(summary = "투표 좋아요")
-    public ResponseEntity<String> like(@PathVariable String share_id, @RequestParam String store_id,HttpSession session){
+    public ResponseEntity<String> like(@PathVariable String url, @RequestParam String store_id,HttpSession session){
 
         Long memberId = (Long) session.getAttribute("memberId");
         if (memberId == null) {
             throw new CustomException(ErrorCode.REQUEST_LOGIN);
         }
 
-        return new ResponseEntity<>(shareService.like(share_id, store_id), HttpStatus.OK);
+        return new ResponseEntity<>(shareService.like(url, store_id), HttpStatus.OK);
     }
 
 
     /**
      * 투표 좋아요 취소
-     * url : /share/{share_id}/vote?store={store_id}
+     * url : /share/{url}/vote?store={store_id}
      * */
-    @PatchMapping("/share/{share_id}/vote")
+    @PatchMapping("/share/{url}/vote")
     @Operation(summary = "투표 좋아요 취소")
-    public ResponseEntity<String> likeCancel(@PathVariable String share_id, @RequestParam String store_id,HttpSession session){
+    public ResponseEntity<String> likeCancel(@PathVariable String url, @RequestParam String store_id,HttpSession session){
 
         Long memberId = (Long) session.getAttribute("memberId");
         if (memberId == null) {
             throw new CustomException(ErrorCode.REQUEST_LOGIN);
         }
 
-        return new ResponseEntity<>(shareService.likeCancel(share_id, store_id), HttpStatus.OK);
+        return new ResponseEntity<>(shareService.likeCancel(url, store_id), HttpStatus.OK);
     }
 
     /**
      * 투표 결과 보기
      * url : /share/{share_id}/result
      * */
-    @GetMapping("/share/{share_id}/result")
+    @GetMapping("/share/{url}/result")
     @Operation(summary = "투표 결과 보기")
-    public ResponseEntity<List<StoreResponse>> showResult(@PathVariable String share_id,HttpSession session){
+    public ResponseEntity<List<StoreResponse>> showResult(@PathVariable String url,HttpSession session){
 
         Long memberId = (Long) session.getAttribute("memberId");
         if (memberId == null) {
             throw new CustomException(ErrorCode.REQUEST_LOGIN);
         }
 
-        return new ResponseEntity<>(shareService.showResult(share_id),HttpStatus.OK);
+        return new ResponseEntity<>(shareService.showResult(url),HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/chimaera/wagubook/dto/response/FollowingResponse.java
+++ b/src/main/java/com/chimaera/wagubook/dto/response/FollowingResponse.java
@@ -20,6 +20,6 @@ public class FollowingResponse {
         this.username = member.getUsername();
         this.memberImageUrl = (u==null) ? null : u;
         this.isEach = follow.isEach();
-        this.isOnLive = member.isOnLive();
+        this.isOnLive = member.isLive();
     }
 }

--- a/src/main/java/com/chimaera/wagubook/entity/Share.java
+++ b/src/main/java/com/chimaera/wagubook/entity/Share.java
@@ -17,7 +17,7 @@ public class Share {
     @Column(name = "share_id")
     private Long id;
     private String url; // 공유 url
-    private LocalDateTime localDateTime; // 공유 시간
+//    private LocalDateTime localDateTime; // 공유 시간
     @Lob
     private HashMap<Long, Integer> voteStoreList;
 

--- a/src/main/java/com/chimaera/wagubook/exception/ErrorCode.java
+++ b/src/main/java/com/chimaera/wagubook/exception/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode {
     NOT_FOUND_FOLLOW(NOT_FOUND, "성립되지 않은 팔로우 관계입니다."),
     NOT_FOUND_SHARE(NOT_FOUND, "공유방을 찾을 수 없습니다."),
     NOT_FOUND_STORE(NOT_FOUND, "해당 스토어를 찾을 수 없습니다."),
+    NOT_FOUND_URL(NOT_FOUND, "해당 url이 존재하지 않습니다."),
 
 
     // 409 CONFLICT: 중복된 리소스 (요청이 현재 서버 상태와 충돌될 때)

--- a/src/main/java/com/chimaera/wagubook/service/RedisService.java
+++ b/src/main/java/com/chimaera/wagubook/service/RedisService.java
@@ -26,12 +26,28 @@ public class RedisService {
         redisTemplate.expire(key, duration);
     }
 
+    // 유효 시간까지 고려할 경우 (Duration 객체 사용)
+    // 사용 예시) redisService.setValues("key", "value", Duration.ofMinutes(5));
+    public void setValuesObject(String key, Object value, Duration duration) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, value);
+        redisTemplate.expire(key, duration);
+    }
+
     /* 조회 */
     // Key를 기반으로 Value 조회
     public String getValue(String key) {
         ValueOperations<String, Object> values = redisTemplate.opsForValue();
         if (values.get(key) == null) return null;
         return String.valueOf(values.get(key));
+    }
+
+    /* 조회 */
+    // Key를 기반으로 Value 조회
+    public Object getObject(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        if (values.get(key) == null) return null;
+        return values.get(key);
     }
 
     /* 삭제 */

--- a/src/main/java/com/chimaera/wagubook/service/ShareService.java
+++ b/src/main/java/com/chimaera/wagubook/service/ShareService.java
@@ -21,6 +21,7 @@ import java.util.*;
 public class ShareService {
     private final ShareRepository shareRepository;
     private final StoreRepository storeRepository;
+    private final RedisService redisService;
 
     public String createUrl(Long memberId) {
 
@@ -40,11 +41,14 @@ public class ShareService {
         //share entity 생성
         Share share = Share.newBuilder()
                 .url(randomCode)
-                .localDateTime(LocalDateTime.now())
+//                .localDateTime(LocalDateTime.now())
                 .voteStoreList(new HashMap<>())
                 .build();
 
         shareRepository.save(share);
+
+        //Redis에 저장
+        redisService.setValuesObject(randomCode, share, Duration.ofMinutes(5));
 
         return randomCode;
     }
@@ -59,24 +63,30 @@ public class ShareService {
     }
 
     public String findShareId(String url, Long memberId) {
-        Optional<Share> os = shareRepository.findByUrl(url);
-        if(os.isPresent()){
-            Share findShare = os.get();
-            //유효기간(30분) 만료 전일 때만 반환
-            Duration duration = Duration.between(findShare.getLocalDateTime(),LocalDateTime.now());
-            System.out.println("localDateTime : " + LocalDateTime.now());
-            System.out.println("ShareDAteTime : " + findShare.getLocalDateTime());
-            System.out.println("duration : "+duration.getSeconds());
-            if(duration.getSeconds() < 1800){
+//        Optional<Share> os = shareRepository.findByUrl(url);
+////        if(os.isPresent()){
+////            Share findShare = os.get();
+////            //유효기간(30분) 만료 전일 때만 반환
+////            Duration duration = Duration.between(findShare.getLocalDateTime(),LocalDateTime.now());
+////            System.out.println("localDateTime : " + LocalDateTime.now());
+////            System.out.println("ShareDAteTime : " + findShare.getLocalDateTime());
+////            System.out.println("duration : "+duration.getSeconds());
+////            if(duration.getSeconds() < 1800){
+////
+////                return "" + findShare.getId();
+////            }
+////        }
+        Share value = (Share)redisService.getObject(url);
+        if(value == null)
+            throw new CustomException(ErrorCode.NOT_FOUND_URL);
+        else
+            return ""+value.getId();
 
-                return "" + findShare.getId();
-            }
-        }
-        return "해당 url이 존재하지 않습니다.";
+//        return "해당 url이 존재하지 않습니다.";
     }
 
     @Transactional
-    public String addVoteStore(String shareId, String storeId) {
+    public String addVoteStore(String url, String storeId) {
         //가게 찾기
         Optional<Store> os =storeRepository.findById(Long.parseLong(storeId));
         if(os.isEmpty()){
@@ -86,15 +96,23 @@ public class ShareService {
 
 
         //공유방에서 리스트 찾기
-        Optional<Share> osh = shareRepository.findById(Long.parseLong(shareId));
-        if(osh.isEmpty()){
-            throw new CustomException(ErrorCode.NOT_FOUND_SHARE);
-        }
-        Share share = osh.get();
+        Share share = (Share)redisService.getObject(url);
+        if(share == null)
+            throw new CustomException(ErrorCode.NOT_FOUND_URL);
+//        Optional<Share> osh = shareRepository.findById(Long.parseLong(shareId));
+//        if(osh.isEmpty()){
+//            throw new CustomException(ErrorCode.NOT_FOUND_SHARE);
+//        }
+//        Share share = osh.get();
         HashMap<Long, Integer> voteStoreList = share.getVoteStoreList();
 
+        System.out.println("[before add]");
+        for (Map.Entry<Long, Integer> entry : voteStoreList.entrySet()) {
+            System.out.println("key : " + entry.getKey() + " value : " + entry.getValue());
+        }
 
         //이미 포함하고 있으면
+        System.out.println(findStore.getId());
         if(voteStoreList.containsKey(findStore.getId()))
             throw new CustomException(ErrorCode.ALREADY_ADD);
 
@@ -104,7 +122,9 @@ public class ShareService {
 
         voteStoreList.put(findStore.getId(), 0);
         //변경사항 저장
-        shareRepository.save(share);
+//        shareRepository.save(share);
+        redisService.setValuesObject(url, share, Duration.ofMinutes(5));
+
         System.out.println("[after add]");
         for (Map.Entry<Long, Integer> entry : voteStoreList.entrySet()) {
             System.out.println("key : " + entry.getKey() + " value : " + entry.getValue());
@@ -113,11 +133,14 @@ public class ShareService {
     }
 
     @Transactional
-    public String deleteVoteStore(String shareId, String storeId) {
+    public String deleteVoteStore(String url, String storeId) {
         //가게 찾기
         Store findStore = storeRepository.findById(Long.parseLong(storeId)).get();
         //공유 엔티티에서 제거
-        Share share = shareRepository.findById(Long.parseLong(shareId)).get();
+        Share share = (Share) redisService.getObject(url);
+        if(share == null)
+            throw new CustomException(ErrorCode.NOT_FOUND_URL);
+//        Share share = shareRepository.findById(Long.parseLong(shareId)).get();
 
         HashMap<Long, Integer> voteStoreList = share.getVoteStoreList();
 
@@ -127,15 +150,20 @@ public class ShareService {
             for (Map.Entry<Long, Integer> entry : voteStoreList.entrySet()) {
                 System.out.println("key : " + entry.getKey() + " value : " + entry.getValue());
             }
-            shareRepository.save(share);
+//            shareRepository.save(share);
+            redisService.setValuesObject(url, share, Duration.ofMinutes(5));
             return "투표에서 삭제되었습니다.";
         }
         return "투표 리스트에 존재하지 않는 가게입니다.";
     }
 
-    public String like(String shareId, String storeId) {
-        //가게 찾기
-        Share share = shareRepository.findById(Long.parseLong(shareId)).get();
+    public String like(String url, String storeId) {
+        //공유 데이터 찾기
+        Share share = (Share) redisService.getObject(url);
+        if(share == null)
+            throw new CustomException(ErrorCode.NOT_FOUND_URL);
+
+//        Share share = shareRepository.findById(Long.parseLong(shareId)).get();
 
         HashMap<Long, Integer> voteStoreList = share.getVoteStoreList();
         Long key = Long.parseLong(storeId);
@@ -146,18 +174,23 @@ public class ShareService {
         for (Map.Entry<Long, Integer> entry : voteStoreList.entrySet()) {
             System.out.println("key : " + entry.getKey() + " value : " + entry.getValue());
         }
-        shareRepository.save(share);
+//        shareRepository.save(share);
+        redisService.setValuesObject(url, share, Duration.ofMinutes(5));
         return "투표 성공";
     }
 
-    public String likeCancel(String shareId, String storeId) {
-        //가게 찾기
-        Share share = shareRepository.findById(Long.parseLong(shareId)).get();
+    public String likeCancel(String url, String storeId) {
+        //공유 데이터 찾기
+        Share share = (Share) redisService.getObject(url);
+        if(share == null)
+            throw new CustomException(ErrorCode.NOT_FOUND_URL);
+//        Share share = shareRepository.findById(Long.parseLong(shareId)).get();
 
         HashMap<Long, Integer> voteStoreList = share.getVoteStoreList();
         Long key = Long.parseLong(storeId);
         voteStoreList.replace(key, voteStoreList.get(key)-1);
-        shareRepository.save(share);
+//        shareRepository.save(share);
+        redisService.setValuesObject(url, share, Duration.ofMinutes(5));
 
         System.out.println("[after cancel]");
         for (Map.Entry<Long, Integer> entry : voteStoreList.entrySet()) {
@@ -166,8 +199,12 @@ public class ShareService {
         return "투표 취소";
     }
 
-    public List<StoreResponse> showResult(String shareId) {
-        Share share = shareRepository.findById(Long.parseLong(shareId)).get();
+    public List<StoreResponse> showResult(String url) {
+        //공유 데이터 찾기
+        Share share = (Share) redisService.getObject(url);
+        if(share == null)
+            throw new CustomException(ErrorCode.NOT_FOUND_URL);
+//        Share share = shareRepository.findById(Long.parseLong(shareId)).get();
 
         HashMap<Long, Integer> voteStoreList = share.getVoteStoreList();
         int max = 0;


### PR DESCRIPTION
### 연관된 이슈
> 예) #15

### 작업 내용
> **Share객체 저장 Redis로 변경**
redis config에 객체 직렬화 변경
share 기능 사용 중 shareId가 아니라 url을 통해 share 객체에 접근할 수 있도록 변경
공유 url 5분으로 설정
투표에 추가, 삭제, 투표 좋아요, 취소 등 사용이 있을 때마다 유효기간 5분으로 다시 설정되도록 구현
