### PR TITLE
store Entity에 liveList 추가

### DIFF
--- a/src/main/java/com/chimaera/wagubook/controller/OpenviduController.java
+++ b/src/main/java/com/chimaera/wagubook/controller/OpenviduController.java
@@ -110,14 +110,16 @@ public class OpenviduController {
      * @return The member ID of the session creator
      */
     @GetMapping("/api/sessions/{sessionId}/creator")
-    public ResponseEntity<Map<String, Object>> getSessionCreator(@PathVariable("sessionId") String sessionId) {
+    public ResponseEntity<Map<String, Object>> getSessionCreator(@PathVariable("sessionId") String sessionId, HttpSession httpSession) {
         Long creatorMemberId = sessionCreatorMap.get(sessionId);
         if (creatorMemberId == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
+        Boolean isCreator = (creatorMemberId == (Long) httpSession.getAttribute("memberId"));
 
         Map<String, Object> response = new HashMap<>();
         response.put("creatorMemberId", creatorMemberId);
+        response.put("isCreator", isCreator);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/chimaera/wagubook/controller/StoreController.java
+++ b/src/main/java/com/chimaera/wagubook/controller/StoreController.java
@@ -1,5 +1,6 @@
 package com.chimaera.wagubook.controller;
 
+import com.chimaera.wagubook.dto.response.LiveResponse;
 import com.chimaera.wagubook.dto.response.StorePostResponse;
 import com.chimaera.wagubook.dto.response.StoreResponse;
 import com.chimaera.wagubook.exception.CustomException;
@@ -66,5 +67,24 @@ public class StoreController {
         }
 
         return new ResponseEntity<>(storeService.getAllPostsByStore(storeId,page,size,memberId), HttpStatus.OK);
+    }
+
+    /**
+     * 식당 아이디로 라이브 리스트 조회
+     * Method : GET
+     * url : /map/posts?storeId={storeId}&page={page}&size={size}
+     * */
+    @GetMapping("/map/live")
+    @Operation(summary = "식당 아이디로 라이브 리스트 조회")
+    public ResponseEntity<List<LiveResponse>> getLiveByStore(
+            @RequestParam(value = "storeId") Long storeId,
+            HttpSession session){
+
+        Long memberId = (Long) session.getAttribute("memberId");
+        if (memberId == null) {
+            throw new CustomException(ErrorCode.REQUEST_LOGIN);
+        }
+
+        return new ResponseEntity<>(storeService.getLiveListByStore(storeId,memberId), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/chimaera/wagubook/dto/response/LiveResponse.java
+++ b/src/main/java/com/chimaera/wagubook/dto/response/LiveResponse.java
@@ -1,0 +1,17 @@
+package com.chimaera.wagubook.dto.response;
+
+import com.chimaera.wagubook.entity.LiveRoom;
+import lombok.Data;
+
+@Data
+public class LiveResponse {
+    String profileImage;    //라이브 중인 사람의 프로필 사진
+    String sessionId;       //라이브 세션 ID
+    String userName;        //라이브 중인 사람의 닉네임
+
+    public LiveResponse(LiveRoom liveRoom){
+        this.profileImage=liveRoom.getMember().getMemberImage().getUrl();
+        this.sessionId=liveRoom.getSessionId();
+        this.userName=liveRoom.getMember().getName();
+    }
+}

--- a/src/main/java/com/chimaera/wagubook/entity/LiveRoom.java
+++ b/src/main/java/com/chimaera/wagubook/entity/LiveRoom.java
@@ -37,4 +37,6 @@ public class LiveRoom {
 
     @OneToMany(mappedBy = "liveRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatMessage> chatMessages = new ArrayList<>(); // 채팅 메시지들
+
+    private String sessionId; // 라이브 스트리밍 세션 ID
 }

--- a/src/main/java/com/chimaera/wagubook/repository/liveRoom/LiveRoomRepository.java
+++ b/src/main/java/com/chimaera/wagubook/repository/liveRoom/LiveRoomRepository.java
@@ -1,7 +1,12 @@
 package com.chimaera.wagubook.repository.liveRoom;
 
 import com.chimaera.wagubook.entity.LiveRoom;
+import com.chimaera.wagubook.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface LiveRoomRepository extends JpaRepository<LiveRoom, Long> {
+    List<LiveRoom> findByStoreId(Long storeId);
 }

--- a/src/main/java/com/chimaera/wagubook/service/StoreService.java
+++ b/src/main/java/com/chimaera/wagubook/service/StoreService.java
@@ -1,12 +1,15 @@
 package com.chimaera.wagubook.service;
 
 
+import com.chimaera.wagubook.dto.response.LiveResponse;
 import com.chimaera.wagubook.dto.response.StorePostResponse;
 import com.chimaera.wagubook.dto.response.StoreResponse;
 import com.chimaera.wagubook.entity.Follow;
+import com.chimaera.wagubook.entity.LiveRoom;
 import com.chimaera.wagubook.entity.Menu;
 
 import com.chimaera.wagubook.entity.Permission;
+import com.chimaera.wagubook.repository.liveRoom.LiveRoomRepository;
 import com.chimaera.wagubook.repository.member.FollowRepository;
 import com.chimaera.wagubook.repository.menu.MenuRepository;
 import com.chimaera.wagubook.repository.post.PostRepository;
@@ -17,6 +20,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.awt.print.Pageable;
+import java.util.ArrayList;
 import java.util.List;
 
 import java.util.Optional;
@@ -29,6 +33,7 @@ public class StoreService {
     private final StoreRepository storeRepository;
     private final PostRepository postRepository;
     private final MenuRepository menuRepository;
+    private final LiveRoomRepository liveRoomRepository;
 
 
     public List<StoreResponse> getStoresByScreen(String left, String right, String up, String down) {
@@ -53,6 +58,17 @@ public class StoreService {
                         return new StorePostResponse(post, post.getMenus().get(0));
                     }
                 })
+                .collect(Collectors.toList());
+    }
+
+    public List<LiveResponse> getLiveListByStore(Long storeId, Long memberId) {
+        List<LiveRoom> liveRoomList = liveRoomRepository.findByStoreId(storeId);
+        if(liveRoomList.isEmpty()){
+            return new ArrayList<>();
+        }
+
+        return liveRoomList.stream()
+                .map(liveRoom -> (new LiveResponse(liveRoom)))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
### 연관된 이슈
> 예) #95

### 작업 내용
> storeId로 라이브 중인 사람들 조회 로직 구현(프로필, sessionId, username 반환)
live_room entity에 sessionId 추가
